### PR TITLE
Remove die() calls and clean up a bit

### DIFF
--- a/src/Authentication/PasswordAuthentication.php
+++ b/src/Authentication/PasswordAuthentication.php
@@ -27,7 +27,7 @@ class PasswordAuthentication implements AuthenticationInterface
     {
         $client = new Client();
 
-        $request = $client->request('post', $this->endPoint . 'services/oauth2/token', ['form_params' => $this->options]);
+        $request = $client->request('post', "{$this->endPoint}services/oauth2/token", ['form_params' => $this->options]);
         $response = json_decode($request->getBody(), true);
 
         if ($response) {

--- a/src/CRUD.php
+++ b/src/CRUD.php
@@ -3,6 +3,7 @@
 namespace bjsmasth\Salesforce;
 
 use GuzzleHttp\Client;
+use Exception\Salesforce as SalesforceException;
 
 class CRUD
 {
@@ -12,7 +13,7 @@ class CRUD
     public function __construct()
     {
         if (!isset($_SESSION) and !isset($_SESSION['salesforce'])) {
-            throw new \Exception('Access Denied', 403);
+            throw new SalesforceException('Access Denied', 403);
         }
 
         $this->instance_url = $_SESSION['salesforce']['instance_url'];
@@ -21,12 +22,12 @@ class CRUD
 
     public function query($query)
     {
-        $url = "$this->instance_url/services/data/v39.0/query";
+        $url = "{$this->instance_url}/services/data/v39.0/query";
 
         $client = new Client();
         $request = $client->request('GET', $url, [
             'headers' => [
-                'Authorization' => "OAuth $this->access_token"
+                'Authorization' => "OAuth {$this->access_token}"
             ],
             'query' => [
                 'q' => $query
@@ -38,13 +39,13 @@ class CRUD
 
     public function create($object, array $data)
     {
-        $url = "$this->instance_url/services/data/v39.0/sobjects/$object/";
+        $url = "{$this->instance_url}/services/data/v39.0/sobjects/{$object}/";
 
         $client = new Client();
 
         $request = $client->request('POST', $url, [
             'headers' => [
-                'Authorization' => "OAuth $this->access_token",
+                'Authorization' => "OAuth {$this->access_token}",
                 'Content-type' => 'application/json'
             ],
             'json' => $data
@@ -53,7 +54,9 @@ class CRUD
         $status = $request->getStatusCode();
 
         if ($status != 201) {
-            die("Error: call to URL $url failed with status $status, response: " . $request->getReasonPhrase());
+            throw new SalesforceException(
+                "Error: call to URL {$url} failed with status {$status}, response: {$request->getReasonPhrase()}"
+            );
         }
 
         $response = json_decode($request->getBody(), true);
@@ -65,7 +68,7 @@ class CRUD
 
     public function update($object, $id, array $data)
     {
-        $url = "$this->instance_url/services/data/v39.0/sobjects/$object/$id";
+        $url = "{$this->instance_url}/services/data/v39.0/sobjects/{$object}/{$id}";
 
         $client = new Client();
 
@@ -80,7 +83,9 @@ class CRUD
         $status = $request->getStatusCode();
 
         if ($status != 204) {
-            die("Error: call to URL $url failed with status $status, response: " . $request->getReasonPhrase());
+            throw new SalesforceException(
+                "Error: call to URL {$url} failed with status {$status}, response: {$request->getReasonPhrase()}"
+            );
         }
 
         return $status;
@@ -88,13 +93,13 @@ class CRUD
 
     public function upsert($object, $field, $id, array $data)
     {
-        $url = "$this->instance_url/services/data/v39.0/sobjects/$object/$field/$id";
+        $url = "{$this->instance_url}/services/data/v39.0/sobjects/{$object}/{$field}/{$id}";
 
         $client = new Client();
 
         $request = $client->request('PATCH', $url, [
             'headers' => [
-                'Authorization' => "OAuth $this->access_token",
+                'Authorization' => "OAuth {$this->access_token}",
                 'Content-type' => 'application/json'
             ],
             'json' => $data
@@ -103,27 +108,31 @@ class CRUD
         $status = $request->getStatusCode();
 
         if ($status != 204 && $status != 201) {
-            die("Error: call to URL $url failed with status $status, response: " . $request->getReasonPhrase());
+            throw new SalesforceException(
+                "Error: call to URL {$url} failed with status {$status}, response: {$request->getReasonPhrase()}"
+            );
         }
 
         return $status;
     }
-    
+
     public function delete($object, $id)
     {
-        $url = "$this->instance_url/services/data/v39.0/sobjects/$object/$id";
+        $url = "{$this->instance_url}/services/data/v39.0/sobjects/{$object}/{$id}";
 
         $client = new Client();
         $request = $client->request('DELETE', $url, [
             'headers' => [
-                'Authorization' => "OAuth $this->access_token",
+                'Authorization' => "OAuth {$this->access_token}",
             ]
         ]);
 
         $status = $request->getStatusCode();
 
         if ($status != 204) {
-            die("Error: call to URL $url failed with status $status, response: " . $request->getReasonPhrase());
+            throw new SalesforceException(
+                "Error: call to URL {$url} failed with status {$status}, response: {$request->getReasonPhrase()}"
+            );
         }
 
         return true;


### PR DESCRIPTION
Just a bit of cleanup and replacing the `die()` calls with exceptions. die() should generally not be used (particularly in libraries) as there is no way to properly handle the error.