### PR TITLE
Fix upsert example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Upsert
        'Name' => 'another name',
     ];
     
-    $crud->update('Account', 'API Name/ Field Name', 'value', $new_data); #returns status_code 204 or 201
+    $crud->upsert('Account', 'API Name/ Field Name', 'value', $new_data); #returns status_code 204 or 201
     
 ```
 


### PR DESCRIPTION
The upsert example got a copy past error and called `$crud->update` instead of `$crud->upsert`