### PR TITLE
Allow use with Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "guzzlehttp/guzzle": "^6.2",
+    "guzzlehttp/guzzle": "^6.2 || ^7",
     "php": ">=5.5"
   },
   "autoload": {


### PR DESCRIPTION
All uses of Guzzle haven't had API changes between 6.x and 7.x, so we're safe here.